### PR TITLE
Added controller and view for message queue

### DIFF
--- a/src/lib/src/message_queue.ex
+++ b/src/lib/src/message_queue.ex
@@ -10,14 +10,14 @@ defmodule Src.MessageQueue do
   end
 
   def add_message(message, topic) do
-    GenServer.call(topic, {:add_message, message})
+    GenServer.call(topic, {:add_message, message}, :infinity)
   end
 
   def handle_call({:add_message, message}, _from, state) do
     # add message to queue
     state = [message | state]
     # wait for previous job to finish
-    Process.sleep(1000)
+    Process.sleep(5000)
     # do a job
     IO.puts("Message: #{message}")
     {:reply, :ok, state}

--- a/src/lib/src_web/controllers/message_queue_controller.ex
+++ b/src/lib/src_web/controllers/message_queue_controller.ex
@@ -1,0 +1,26 @@
+defmodule SrcWeb.MessageQueueController do
+  use SrcWeb, :controller
+
+  alias Src.MessageQueue
+
+  action_fallback SrcWeb.FallbackController
+
+  # requires a message and topic in body
+  def receive_message(conn, %{"message" => message, "topic" => topic}) do
+    # check if genserver message queue with topic exists
+    if Process.whereis(String.to_atom(topic)) == nil do
+      # if not, start genserver message queue with topic
+      MessageQueue.start_link(String.to_atom(topic))
+    end
+    Task.async(fn -> MessageQueue.add_message(message, String.to_existing_atom(topic)) end)
+    messages = %{
+      message: message,
+      topic: topic
+    }
+    conn
+    |> put_status(:created)
+    |> render("show.json", message: messages)
+  end
+
+
+end

--- a/src/lib/src_web/router.ex
+++ b/src/lib/src_web/router.ex
@@ -26,6 +26,7 @@ defmodule SrcWeb.Router do
 
     resources "/consumers", ConsumerController, except: [:new, :edit]
     get "/consumers/topic/:topic", ConsumerController, :index_by_topic
+    post "/message_queue", MessageQueueController, :receive_message
   end
 
   # Enables LiveDashboard only for development

--- a/src/lib/src_web/views/message_queue_view.ex
+++ b/src/lib/src_web/views/message_queue_view.ex
@@ -1,0 +1,15 @@
+defmodule SrcWeb.MessageQueueView do
+  use SrcWeb, :view
+  alias SrcWeb.MessageQueueView
+
+  def render("show.json", %{message: messages}) do
+    %{data: render_one(messages, MessageQueueView, "message.json")}
+  end
+
+  def render("message.json", %{message_queue: messages}) do
+    %{
+      message: messages.message,
+      topic: messages.topic
+    }
+  end
+end


### PR DESCRIPTION
Kudos to Haydar for assisting!
We added basic controllers for producer to input the topic and message. If topic doesn't exist, create new queue with the topic. For now, the handle call only do sleep for 5 seconds to imitate the consumer processing. 